### PR TITLE
Fix/discriminators

### DIFF
--- a/neosr/models/image.py
+++ b/neosr/models/image.py
@@ -580,12 +580,9 @@ class image(base):
                 loss_dict["l_g_gw"] = l_g_gw
             # gan loss
             if self.cri_gan:
-                if self.ema > 0:
-                    self.net_d_ema.eval()
-                    fake_g_pred = self.net_d_ema(self.output)  # type: ignore[reportCallIssue,reportOptionalCall]
-                else:
-                    self.net_d.eval()
-                    fake_g_pred = self.net_d(self.output)  # type: ignore[reportCallIssue,reportOptionalCall]
+                self.net_d.eval()
+                fake_g_pred = self.net_d(self.output)  # type: ignore[reportCallIssue,reportOptionalCall]
+                self.net_d.train()
                 l_g_gan = self.cri_gan(fake_g_pred, target_is_real=True, is_disc=False)
                 l_g_total += l_g_gan
                 loss_dict["l_g_gan"] = l_g_gan

--- a/neosr/models/image.py
+++ b/neosr/models/image.py
@@ -580,7 +580,12 @@ class image(base):
                 loss_dict["l_g_gw"] = l_g_gw
             # gan loss
             if self.cri_gan:
-                fake_g_pred = self.net_d(self.output)  # type: ignore[reportCallIssue,reportOptionalCall]
+                if self.ema > 0:
+                    self.net_d_ema.eval()
+                    fake_g_pred = self.net_d_ema(self.output)  # type: ignore[reportCallIssue,reportOptionalCall]
+                else:
+                    self.net_d.eval()
+                    fake_g_pred = self.net_d(self.output)  # type: ignore[reportCallIssue,reportOptionalCall]
                 l_g_gan = self.cri_gan(fake_g_pred, target_is_real=True, is_disc=False)
                 l_g_total += l_g_gan
                 loss_dict["l_g_gan"] = l_g_gan


### PR DESCRIPTION
MetaGan dropout 0.2
red eval gan loss - blue no eval gan loss
![изображение](https://github.com/user-attachments/assets/8d01c9e7-4d73-4a08-a8e7-edff42df8a3e)

The core idea is that the use of DropOut in GAN loss functions based on A-2FPN and MetaGan introduces noise into lg_loss values. This, in turn, can lead to significant model divergence during training.