### PR TITLE
Fixed that LQ image is written on every validation run

### DIFF
--- a/neosr/models/image.py
+++ b/neosr/models/image.py
@@ -924,8 +924,10 @@ class image(base):
                 # add original lq and gt to results folder, once
                 if self.opt["val"].get("save_lq", True):
                     save_lq_img_path = Path(v_folder) / img_name / f"{img_name}_lq.png"
-                    original_lq = tensor2img([visuals["lq"]])
-                    imwrite(original_lq, str(save_lq_img_path))
+
+                    if not Path.is_file(save_lq_img_path):
+                        original_lq = tensor2img([visuals["lq"]])
+                        imwrite(original_lq, str(save_lq_img_path))
 
             # check for dataset option save_tb, to save images on tb_logger
             if self.is_train:


### PR DESCRIPTION
There's currently no check for existing LQ images. Meaning it'd be written to disk every time validation is run.