### PR TITLE
fix: auto resume not respected / ignored

### DIFF
--- a/neosr/data/__init__.py
+++ b/neosr/data/__init__.py
@@ -127,6 +127,14 @@ def build_dataloader(
             "shuffle": False,
             "num_workers": 0,
         }
+    # evaluation
+    elif phase in {"eval"}:
+        dataloader_args = {
+            "dataset": dataset,
+            "batch_size": 1,
+            "shuffle": False,
+            "num_workers": 0,
+        }
     else:
         msg = f"Wrong dataset phase: {phase}. Supported ones are 'train', 'val' and 'test'."
         raise ValueError(msg)

--- a/neosr/data/data_util.py
+++ b/neosr/data/data_util.py
@@ -156,12 +156,12 @@ def paired_paths_from_folder(
 
     input_paths = [
         path
-        for path in scandir(input_folder, recursive=True, full_path=True)
+        for path in scandir(input_folder, recursive=False, full_path=True)
         if path.lower().endswith(extensions)
     ]
     gt_paths = [
         path
-        for path in scandir(gt_folder, recursive=True, full_path=True)
+        for path in scandir(gt_folder, recursive=False, full_path=True)
         if path.lower().endswith(extensions)
     ]
 

--- a/neosr/models/base.py
+++ b/neosr/models/base.py
@@ -85,6 +85,32 @@ class base:
         else:
             self.nondist_validation(dataloader, current_iter, tb_logger, save_img)
 
+    def dist_model_evaluation(
+        self, dataloader, current_iter: int
+    ) -> None:
+        pass
+
+    def nondist_model_evaluation(
+        self, dataloader, current_iter: int
+    ) -> None:
+        pass
+
+    def evaluation(
+        self, dataloader, current_iter: int
+    ) -> None:
+        """Evaluation function.
+
+        Args:
+        ----
+            dataloader (torch.utils.data.DataLoader): Evaluation dataloader.
+            current_iter (int): Current iteration.
+
+        """
+        if self.opt["dist"]:
+            self.dist_evaluation(dataloader, current_iter)
+        else:
+            self.nondist_evaluation(dataloader, current_iter)
+
     def _initialize_best_metric_results(self, dataset_name: str) -> None:
         """Initialize the best metric results dict for recording the best metric value and iteration."""
         self.best_metric_results: dict[Any, Any]

--- a/neosr/models/image.py
+++ b/neosr/models/image.py
@@ -922,10 +922,12 @@ class image(base):
                 imwrite(sr_img, str(save_img_path))  # type: ignore[arg-type]
 
                 # add original lq and gt to results folder, once
-                if self.opt["val"].get("save_lq", True):
+                if self.opt["val"].get("save_lq", False) or self.opt["val"].get("copy_lq", False):
                     save_lq_img_path = Path(v_folder) / img_name / f"{img_name}_lq.png"
-                    original_lq = tensor2img([visuals["lq"]])
-                    imwrite(original_lq, str(save_lq_img_path))
+
+                    if not Path.is_file(save_lq_img_path):
+                        original_lq = tensor2img([visuals["lq"]])
+                        imwrite(original_lq, str(save_lq_img_path))
 
             # check for dataset option save_tb, to save images on tb_logger
             if self.is_train:

--- a/neosr/utils/options.py
+++ b/neosr/utils/options.py
@@ -258,6 +258,7 @@ def parse_options(
             opt["path"]["training_states"] = Path(experiments_root) / "training_states"
             opt["path"]["log"] = experiments_root
             opt["path"]["visualization"] = Path(experiments_root) / "visualization"
+            opt["path"]["evaluation"] = Path(experiments_root) / "evaluation"
 
             # change some options for debug mode
             if "debug" in opt["name"]:

--- a/train.py
+++ b/train.py
@@ -138,7 +138,7 @@ def create_train_val_dataloader(
 def load_resume_state(opt: dict[str, Any]):
     resume_state_path = None
     if opt["auto_resume"]:
-        state_path = Path("experiments") / opt["name"] / "training_states"
+        state_path = opt["path"]["training_states"]
         if Path.is_dir(state_path):
             states = list(
                 scandir(state_path, suffix="state", recursive=False, full_path=False)


### PR DESCRIPTION
If the user sets the experiments_root in the path section of the options file the --auto_resume flag will not work anymore since the code will still check for the training_states folder in the default experiments folder.