### PR TITLE
fix: auto_resume command line flag isn't respected when when setting experiments_root

### DIFF
--- a/train.py
+++ b/train.py
@@ -126,7 +126,7 @@ def create_train_val_dataloader(
 def load_resume_state(opt: dict[str, Any]):
     resume_state_path = None
     if opt["auto_resume"]:
-        state_path = Path("experiments") / opt["name"] / "training_states"
+        state_path = opt["path"]["training_states"]
         if Path.is_dir(state_path):
             states = list(
                 scandir(state_path, suffix="state", recursive=False, full_path=False)


### PR DESCRIPTION
If the user sets the experiments_root in the path section of the options file the --auto_resume flag will not work anymore since the code will still check for the training_states folder in the default experiments folder.